### PR TITLE
fix: correct LSP stdio connection handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "npl-dev-vscode-extension",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npl-dev-vscode-extension",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "vscode-languageclient": "^9.0.1",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-textdocument": "^1.0.12"
+        "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -5654,18 +5652,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
@@ -5675,12 +5661,6 @@
         "vscode-jsonrpc": "8.2.0",
         "vscode-languageserver-types": "3.17.5"
       }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,6 @@
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.1",
-    "vscode-languageserver": "^9.0.1",
-    "vscode-languageserver-textdocument": "^1.0.12"
+    "vscode-languageclient": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   "engines": {
     "vscode": "^1.92.0"
   },
-  "activationEvents": [
-    "onLanguage:npl"
-  ],
   "categories": [
     "Programming Languages",
     "Linters"


### PR DESCRIPTION
Refactors ServerManager to rely on LanguageClient for standard LSP initialization, removing previous faulty logic that caused connection errors. Adds handling for server logs/traces now correctly directed to stderr, preventing LSP stream corruption.

Ticket: ST-4538