### PR TITLE
feat: publish to open-vsx

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -38,17 +38,17 @@ jobs:
 
       - name: Package Extension
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'
-        run: npx vsce package
+        run: npm run package
 
       - name: Publish to Visual Studio Marketplace
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'
-        run: npx vsce publish
+        run: npm run publish:vsce
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish to open-vsx
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'
-        run: npx ovsx publish *.vsix -p ${{ secrets.OPEN_VSX_AT }}
+        run: npm run publish:ovsx -- -p ${{ secrets.OPEN_VSX_AT }}
 
       - name: Create GitHub Release
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -46,6 +46,10 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+      - name: Publish to open-vsx
+        if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'
+        run: npx ovsx publish *.vsix -p ${{ secrets.OPEN_VSX_AT }}
+
       - name: Create GitHub Release
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'
         uses: ncipollo/release-action@v1

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish to open-vsx
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'
-        run: npm run publish:ovsx -- -p ${{ secrets.OPEN_VSX_AT }}
+        run: npm run publish:ovsx -- -p ${{ secrets.OPEN_VSX_PAT }}
 
       - name: Create GitHub Release
         if: steps.check-publish.outputs.PUBLISH_FLAG == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "glob": "^11.0.1",
         "minimatch": "^10.0.1",
         "mocha": "^11.1.0",
+        "ovsx": "^0.10.1",
         "sinon": "^19.0.2",
         "typescript": "^5.8.2",
         "vscode-test": "^1.6.1"
@@ -1568,6 +1569,13 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
@@ -2635,6 +2643,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3158,6 +3187,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-docker": {
@@ -4305,6 +4347,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ovsx": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.1.tgz",
+      "integrity": "sha512-8i7+MJMMeq73m1zPEIClSFe17SNuuzU5br7G77ZIfOC24elB4pGQs0N1qRd+gnnbyhL5Qu96G21nFOVOBa2OBg==",
+      "dev": true,
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@vscode/vsce": "^3.2.1",
+        "commander": "^6.2.1",
+        "follow-redirects": "^1.14.6",
+        "is-ci": "^2.0.0",
+        "leven": "^3.1.0",
+        "semver": "^7.6.0",
+        "tmp": "^0.2.3",
+        "yauzl": "^3.1.3"
+      },
+      "bin": {
+        "ovsx": "lib/ovsx"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ovsx/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ovsx/node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
     "test": "node ./out/test/runTest.js",
-    "package": "vsce package"
+    "package": "vsce package",
+    "publish:vsce": "vsce publish",
+    "publish:ovsx": "ovsx publish *.vsix"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
@@ -86,6 +88,7 @@
     "glob": "^11.0.1",
     "minimatch": "^10.0.1",
     "mocha": "^11.1.0",
+    "ovsx": "^0.10.1",
     "sinon": "^19.0.2",
     "typescript": "^5.8.2",
     "vscode-test": "^1.6.1"


### PR DESCRIPTION
Also publishes the extension to opne-vsx such that it becomes available in VS Code forks like Cursor.

Ticket: ST-4564
