### PR TITLE
fix: add activation event for NPL files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 [//]: # "Add stuff here"
 
+## [1.3.2]
+
+### Changed
+
+- NPL-dev now gets activated whenever a workspace contains NPL files, not just when you open them.
+
 ## [1.3.1]
+
+### Fixed
 
 - Fixed issues with the AI instruction file management
 
 ## [1.3.0]
+
+### Added
 
 - Added a Noumena Cloud view accessible from the activity bar. After logging into your Noumena Cloud account via your
   browser (using the device code flow), you can view your tenants and applications, deploy code, or clear their

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npl-dev-vscode-extension",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npl-dev-vscode-extension",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "npl-dev-vscode-extension",
   "displayName": "NPL-Dev for VS Code",
   "description": "NOUMENA Protocol Language (NPL) development support for VS Code",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "icon": "icon.png",
   "publisher": "noumenadigital",
   "license": "Apache-2.0",
@@ -16,6 +16,9 @@
   "categories": [
     "Programming Languages",
     "Linters"
+  ],
+  "activationEvents": [
+    "workspaceContains:**/*.npl"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
Ensures the plugin gets activated if a workspace contains NPL files, not just when they are opened.