### PR TITLE
fix: only detect frontend/dist when deploying frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). -->
 
-## Unreleased
+## [1.3.7]
+
+### Fixed
+
+- When deploying static frontends, we now only attempt to detect if you have a "frontend/dist" folder, and don't care if
+  you have a "frontend" folder as such.
 
 ## [1.3.6]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npl-dev-vscode-extension",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npl-dev-vscode-extension",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "npl-dev-vscode-extension",
   "displayName": "NPL-Dev for VS Code",
   "description": "NOUMENA Protocol Language (NPL) development support for VS Code",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "icon": "icon.png",
   "publisher": "noumenadigital",
   "license": "Apache-2.0",

--- a/src/cloud/CloudAppsProvider.ts
+++ b/src/cloud/CloudAppsProvider.ts
@@ -380,64 +380,41 @@ export class CloudAppsProvider implements vscode.TreeDataProvider<CloudItem> {
     for (const folder of workspaceFolders) {
       // First check for frontend/dist (most common for built files)
       const frontendDistPath = path.join(folder.uri.fsPath, 'frontend', 'dist');
+      let frontendDistExists = false;
       try {
         const stat = await fs.promises.stat(frontendDistPath);
-        if (stat.isDirectory()) {
-          const choice = await vscode.window.showInformationMessage(
-            `Found a 'frontend/dist' folder. Would you like to deploy from there?`,
-            'Use Frontend/Dist',
-            'Configure Different Folder',
-            'Cancel'
-          );
-
-          if (choice === 'Use Frontend/Dist') {
-            // Save this choice for future deployments
-            const config = vscode.workspace.getConfiguration('NPL', folder.uri);
-            await config.update('frontendSources', frontendDistPath, vscode.ConfigurationTarget.WorkspaceFolder);
-            return frontendDistPath;
-          } else if (choice === 'Configure Different Folder') {
-            void vscode.commands.executeCommand('workbench.action.openSettings', 'NPL.frontendSources');
-            return undefined;
-          } else {
-            return undefined;
-          }
-        }
+        frontendDistExists = stat.isDirectory();
       } catch (err) {
-        // Directory doesn't exist, continue checking
+        // Directory doesn't exist
       }
 
-      // Fallback: check for just 'frontend' folder
-      const frontendPath = path.join(folder.uri.fsPath, 'frontend');
-      try {
-        const stat = await fs.promises.stat(frontendPath);
-        if (stat.isDirectory()) {
-          const choice = await vscode.window.showInformationMessage(
-            `Found a 'frontend' folder. Would you like to deploy from there?`,
-            'Use Frontend Folder',
-            'Configure Different Folder',
-            'Cancel'
-          );
+      if (frontendDistExists) {
+        const choice = await vscode.window.showInformationMessage(
+          `Found a 'frontend/dist' folder. Would you like to deploy from there?`,
+          'Use Frontend/Dist',
+          'Configure Different Folder',
+          'Cancel'
+        );
 
-          if (choice === 'Use Frontend Folder') {
-            // Save this choice for future deployments
-            const config = vscode.workspace.getConfiguration('NPL', folder.uri);
-            await config.update('frontendSources', frontendPath, vscode.ConfigurationTarget.WorkspaceFolder);
-            return frontendPath;
-          } else if (choice === 'Configure Different Folder') {
-            void vscode.commands.executeCommand('workbench.action.openSettings', 'NPL.frontendSources');
-            return undefined;
-          } else {
-            return undefined;
-          }
+        if (choice === 'Use Frontend/Dist') {
+          // Save this choice for future deployments
+          const config = vscode.workspace.getConfiguration('NPL', folder.uri);
+          await config.update('frontendSources', frontendDistPath, vscode.ConfigurationTarget.WorkspaceFolder);
+          return frontendDistPath;
+        } else if (choice === 'Configure Different Folder') {
+          void vscode.commands.executeCommand('workbench.action.openSettings', 'NPL.frontendSources');
+          return undefined;
+        } else {
+          return undefined;
         }
-      } catch (err) {
-        // Directory doesn't exist, continue checking
       }
+
+
     }
 
-    // No frontend folder found, prompt to configure
+    // No frontend/dist folder found, prompt to configure
     const choice = await vscode.window.showErrorMessage(
-      'No frontend sources configured and no "frontend/dist" or "frontend" folder found in the workspace. Please configure the frontend sources path.',
+      'No sources configured and no "frontend/dist" folder found in the workspace. Please configure the sources path.',
       'Configure',
       'Cancel'
     );


### PR DESCRIPTION
Deploying "frontend" as such is typically nonsensical

Ticket: ST-4654
